### PR TITLE
Set default data type for primary in common app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Django Starter Template
 
+![Django CI](https://github.com/kylase/django-starter-template/actions/workflows/django.yml/badge.svg)
+
 This is a simple template for quick kickstart of Django projects. The dependencies required in this template are:
 1. `pytest`, `pytest-django`, `pytest-cov` for testing
 1. `django-extensions` and `ipython` for enhanced shell

--- a/common/apps.py
+++ b/common/apps.py
@@ -2,4 +2,5 @@ from django.apps import AppConfig
 
 
 class CommonConfig(AppConfig):
+    default_auto_field = 'django.db.models.AutoField'
     name = 'common'


### PR DESCRIPTION
Closes #154 

Refer to Django 3.2 release note on [auto-created primary keys](https://docs.djangoproject.com/en/3.2/releases/3.2/#customizing-type-of-auto-created-primary-keys).

